### PR TITLE
feat: add pointer-events: auto to iframe

### DIFF
--- a/.changeset/silver-fans-march.md
+++ b/.changeset/silver-fans-march.md
@@ -1,0 +1,5 @@
+---
+'@blocto/sdk': patch
+---
+
+adjust iframe style

--- a/packages/blocto-sdk/src/lib/frame.ts
+++ b/packages/blocto-sdk/src/lib/frame.ts
@@ -1,5 +1,5 @@
 const IFRAME_STYLE =
-  'width:100vw;height:100%;position:fixed;top:0;left:0;z-index:2147483646;border:none;box-sizing:border-box;color-scheme:light;inset:0px;display:block;';
+  'width:100vw;height:100%;position:fixed;top:0;left:0;z-index:2147483646;border:none;box-sizing:border-box;color-scheme:light;inset:0px;display:block;pointer-events:auto;';
 
 export function createFrame(url: string): HTMLIFrameElement {
   const frame = document.createElement('iframe');


### PR DESCRIPTION
## Summary

<!--- Provide enough context about what you’re trying to achieve. You can break it down in a few bullet-points.-->
when clicking the approve button, it will pass through to the ThirdWeb modal.
add `pointer-events: auto` to offset the `pointer-events: none` setting

<img width="597" alt="image" src="https://github.com/blocto/blocto-sdk/assets/46014714/e2db5dd8-c46f-4608-954e-6f1b39336f97">



## Related Links

<!-- Asana Ticket / Mockup Design Prototype -->

**Asana**:

## Checklist

- [ ] Pasted Asana link.
- [ ] Tagged labels.

## Prerequisite/Related Pull Requests

<!-- Please paste the related PR links. -->
