### PR TITLE
Fix/wagmi connector replace rpc source

### DIFF
--- a/.changeset/chatty-apricots-nail.md
+++ b/.changeset/chatty-apricots-nail.md
@@ -1,0 +1,5 @@
+---
+'@blocto/wagmi-connector': patch
+---
+
+enhance wagmi connector rpc stability

--- a/adapters/wagmi-connector/src/bloctoConnector.ts
+++ b/adapters/wagmi-connector/src/bloctoConnector.ts
@@ -71,8 +71,7 @@ class BloctoConnector extends Connector<BloctoProvider, BloctoOptions> {
         chainId: _chainId,
         rpc:
           rests?.rpc ??
-          this.chains.find((x) => x.id === _chainId)?.rpcUrls.infura?.http[0] ??
-          '',
+          this.chains.find((x) => x.id === _chainId)?.rpcUrls.default.http?.[0],
       };
       this.#provider = new BloctoSDK({ ethereum: config, appId })?.ethereum;
     }


### PR DESCRIPTION
## Summary

<!--- Provide enough context about what you’re trying to achieve. You can break it down in a few bullet-points.-->
replacing the rpc source for `bloctoSDK` in `wagmi-connector` from `Infura` to `default`, in order to gain broader provider support and enhance stability .

## Related Links

<!-- Asana Ticket / Mockup Design Prototype -->

**Asana**:

## Checklist

- [ ] Pasted Asana link.
- [x] Tagged labels.

## Prerequisite/Related Pull Requests

<!-- Please paste the related PR links. -->
