### PR TITLE
fix: go login flow when switching to a different blocto server

### DIFF
--- a/.changeset/grumpy-queens-flash.md
+++ b/.changeset/grumpy-queens-flash.md
@@ -1,0 +1,9 @@
+---
+'@blocto/connectkit-connector': patch
+'@blocto/rainbowkit-connector': patch
+'@blocto/web3-react-connector': patch
+'@blocto/wagmi-connector': patch
+'@blocto/sdk': patch
+---
+
+Fix go login flow when switching to a different blocto server

--- a/packages/blocto-sdk/src/providers/ethereum.ts
+++ b/packages/blocto-sdk/src/providers/ethereum.ts
@@ -704,6 +704,31 @@ export default class EthereumProvider
       this.#getBloctoProperties();
       return null;
     }
+    // Go login flow when switching to a different blocto server
+    if (
+      switchableNetwork[newChainId].wallet_web_url !==
+      switchableNetwork[oldChainId].wallet_web_url
+    ) {
+      return this.enable()
+        .then(([newAccount]) => {
+          if (newAccount !== oldAccount) {
+            this.eventListeners?.accountsChanged.forEach((listener) =>
+              listener([newAccount])
+            );
+          }
+          this.eventListeners.chainChanged.forEach((listener) =>
+            listener(this.chainId)
+          );
+          return null;
+        })
+        .catch((error) => {
+          this.networkVersion = `${oldChainId}`;
+          this.chainId = `0x${oldChainId.toString(16)}`;
+          this.rpc = switchableNetwork[oldChainId].rpc_url;
+          this.#getBloctoProperties();
+          throw error;
+        });
+    }
 
     const switchChainFrame = await this.setIframe(
       `/switch-chain?to=${switchableNetwork[newChainId].name}`,


### PR DESCRIPTION
## Summary

Problem: need login again when switching from different type of chains (testnet/mainnet)
Call enable(login flow) when switching to different blocto wallet server.

## Related Links

<!-- Asana Ticket / Mockup Design Prototype -->

**Asana**:

## Checklist

- [ ] Pasted Asana link.
- [ ] Tagged labels.

## Prerequisite/Related Pull Requests

<!-- Please paste the related PR links. -->
