### PR TITLE
fix: skip calling enable() when request wallet_disconnect method

### DIFF
--- a/.changeset/gold-kids-grin.md
+++ b/.changeset/gold-kids-grin.md
@@ -1,0 +1,10 @@
+---
+'@blocto/connectkit-connector': patch
+'@blocto/rainbowkit-connector': patch
+'@blocto/web3-react-connector': patch
+'@blocto/web3modal-connector': patch
+'@blocto/wagmi-connector': patch
+'@blocto/sdk': patch
+---
+
+Fix skip calling enable() when request wallet_disconnect method

--- a/packages/blocto-sdk/src/providers/ethereum.ts
+++ b/packages/blocto-sdk/src/providers/ethereum.ts
@@ -353,6 +353,9 @@ export default class EthereumProvider
       case 'wallet_switchEthereumChain': {
         return this.handleSwitchChain(payload?.params?.[0]?.chainId);
       }
+      case 'wallet_disconnect': {
+        return this.handleDisconnect();
+      }
     }
 
     // Method that requires user to be connected
@@ -384,11 +387,6 @@ export default class EthereumProvider
         case 'personal_sign':
         case 'eth_sign': {
           result = await this.handleSign(payload);
-          break;
-        }
-        case 'wallet_disconnect': {
-          this.handleDisconnect();
-          result = null;
           break;
         }
         case 'eth_sendTransaction':


### PR DESCRIPTION
## Summary

Skip calling enable() when request `wallet_disconnect` method to prevent some connector call disconnect before connected.

## Related Links

<!-- Asana Ticket / Mockup Design Prototype -->

**Asana**:

## Checklist

- [ ] Pasted Asana link.
- [ ] Tagged labels.

## Prerequisite/Related Pull Requests

<!-- Please paste the related PR links. -->
