### PR TITLE
chore: fix build failed with cache and changed PR bot token

### DIFF
--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -45,19 +45,19 @@ jobs:
           commit_options: '--no-verify'
 
       - name: Create Release Pull Request to main branch
-        uses: repo-sync/pull-request@v2
+        uses: peter-evans/create-pull-request@v5
         with:
-          source_branch: ${{ github.head_ref }}
-          destination_branch: 'main'
-          pr_title: 'Release: Merge to publish new version to npm'
-          pr_body: |
+          token: ${{ secrets.DEV_GITHUB_TOKEN }} 
+          branch: 'main'
+          title: 'Release: Merge to publish new version to npm'
+          body: |
             Please review and merge this Pull Request.
             Caution: Merge to main branch will trigger publish to npm.
 
       - name: Create Release Pull Request to develop branch
-        uses: repo-sync/pull-request@v2
+        uses: peter-evans/create-pull-request@v5
         with:
-          source_branch: ${{ github.head_ref }}
-          destination_branch: 'develop'
-          pr_title: 'Release: Merge back new version to develop'
-          pr_body: 'Merge new prod release back to develop'
+          token: ${{ secrets.DEV_GITHUB_TOKEN }} 
+          branch: 'develop'
+          title: 'Release: Merge back new version to develop'
+          body: 'Merge new prod release back to develop'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,4 +31,11 @@ jobs:
         run: yarn
 
       - name: Lint, Test, and Try to Build
+        id: testWithCache
         run: yarn turbo lint test build --cache-dir=.turbo
+        continue-on-error: true
+      
+      - name: Try to do again without cache
+        if: failure() && steps.testWithCache.outcome == 'failure'
+        run: yarn turbo lint test build --force --cache-dir=.turbo
+        


### PR DESCRIPTION
## Summary

This is a fix for GitHub Action flows.
### Fix 1
Will try to build and test again without cache when cache step gets error

### Fix 2
Change create pull-request bot from `repo-sync/pull-request@v2` to `peter-evans/create-pull-request@v5` beacuse:
  - `repo-sync/pull-request@v2` no longer maintained
  - Need support of using GitHub PAT token to create pull-request instead of using GitHub bot. The pull-request triggered by GitHub bot won't trigger further actions like test and build due to GitHub's policy. [Read more about this](https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs)
