### PR TITLE
fix(ci): use gh cli create pull request instead

### DIFF
--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -44,20 +44,12 @@ jobs:
           commit_message: 'ci: bump package version'
           commit_options: '--no-verify'
 
-      - name: Create Release Pull Request to main branch
-        uses: peter-evans/create-pull-request@v5
-        with:
-          token: ${{ secrets.DEV_GITHUB_TOKEN }} 
-          branch: 'main'
-          title: 'Release: Merge to publish new version to npm'
-          body: |
-            Please review and merge this Pull Request.
-            Caution: Merge to main branch will trigger publish to npm.
-
-      - name: Create Release Pull Request to develop branch
-        uses: peter-evans/create-pull-request@v5
-        with:
-          token: ${{ secrets.DEV_GITHUB_TOKEN }} 
-          branch: 'develop'
-          title: 'Release: Merge back new version to develop'
-          body: 'Merge new prod release back to develop'
+      - name: Create Release Pull Requests
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MAIN_TITLE: 'Release: Merge to publish new version to npm'
+          MAIN_BODY: 'Please review and merge this Pull Request. \n**Caution: Merge to main branch will trigger publish to npm.**'
+          DEV_TITLE: 'Release: Merge back new version to develop'
+          DEV_BODY: 'Merge new prod release back to develop'
+        run: |
+          gh pr create --title "$MAIN_TITLE" --body "$MAIN_BODY" --base main && gh pr create --title "$DEV_TITLE" --body "$DEV_BODY" --base develop


### PR DESCRIPTION
## Summary

Directly use gh cli instead of `peter-evans/create-pull-request@v5` to prevent unnecessary permissions