### PR TITLE
fix: use type string instead to support old typescript

### DIFF
--- a/.changeset/funny-elephants-thank.md
+++ b/.changeset/funny-elephants-thank.md
@@ -1,0 +1,10 @@
+---
+'@blocto/connectkit-connector': patch
+'@blocto/rainbowkit-connector': patch
+'@blocto/web3-react-connector': patch
+'@blocto/web3modal-connector': patch
+'@blocto/wagmi-connector': patch
+'@blocto/sdk': patch
+---
+
+Fix export unreconize type for old typescript

--- a/packages/blocto-sdk/src/lib/getEvmSupport.ts
+++ b/packages/blocto-sdk/src/lib/getEvmSupport.ts
@@ -1,5 +1,5 @@
 export interface EvmSupportMapping {
-  [id: `${number}`]: {
+  [id: string]: {
     chain_id: number;
     name: string; // backend defined chain name: ethereum, bsc, …
     display_name: string; // human readable name: Ethereum, Polygon, …


### PR DESCRIPTION
## Summary

![image](https://github.com/blocto/blocto-sdk/assets/4176802/231b84a9-b5dc-4bb1-a9b9-a6265a0705b5)
Old typescript can't reconize this

## Related Links

<!-- Asana Ticket / Mockup Design Prototype -->

**Asana**:

## Checklist

- [ ] Pasted Asana link.
- [ ] Tagged labels.

## Prerequisite/Related Pull Requests

<!-- Please paste the related PR links. -->
