### PR TITLE
fix: check hasEnoughPointsToCreateWallet when close frame

### DIFF
--- a/packages/blocto-sdk/src/providers/ethereum.ts
+++ b/packages/blocto-sdk/src/providers/ethereum.ts
@@ -786,7 +786,7 @@ export default class EthereumProvider
             if (e.data.type === 'ETH:FRAME:CLOSE') {
               removeListener();
               detatchFrame(switchChainFrame);
-              if (e.data?.hasApprovedSwitchChain) {
+              if (e.data?.hasApprovedSwitchChain && e.data?.hasEnoughPointsToCreateWallet) {
                 this.eventListeners?.chainChanged.forEach((listener) =>
                   listener(this.chainId)
                 );


### PR DESCRIPTION
## Summary

<!--- Provide enough context about what you’re trying to achieve. You can break it down in a few bullet-points.-->

Add a check for `hasEnoughPointsToCreateWallet`. When it returns false, return the user to their previous chain switching state.

## Related Links

<!-- Asana Ticket / Mockup Design Prototype -->

**Asana**:

## Checklist

- [x] Pasted Asana link.
- [x] Tagged labels.

## Prerequisite/Related Pull Requests

<!-- Please paste the related PR links. -->
https://github.com/blocto/wallet-web-ui/pull/327