### PR TITLE
fix: fix removeListener implementation

### DIFF
--- a/packages/blocto-sdk/src/providers/aptos.ts
+++ b/packages/blocto-sdk/src/providers/aptos.ts
@@ -416,7 +416,7 @@ export default class AptosProvider
     if (this.existedSDK)
       this.existedSDK.off(event, listener);
   
-    super.off(event, listener);
+    super.removeListener(event, listener);
   }
   
   off = this.removeListener;

--- a/packages/blocto-sdk/src/providers/ethereum.ts
+++ b/packages/blocto-sdk/src/providers/ethereum.ts
@@ -927,7 +927,7 @@ export default class EthereumProvider
     if (this.existedSDK?.isBlocto)
       this.existedSDK.off(event, listener);
 
-    super.off(event, listener);
+    super.removeListener(event, listener);
   }
 
   off = this.removeListener;


### PR DESCRIPTION
## Summary

<!--- Provide enough context about what you’re trying to achieve. You can break it down in a few bullet-points.-->

fix the incorrect call to BloctoProvider's off method in EthereumProvider's removeListener function.

use `super.removeEventListener` instead of `super.off` because off is a variable, not a method, and can't be called with `super.off(...)`

## Related Links

<!-- Asana Ticket / Mockup Design Prototype -->

**Asana**: https://app.asana.com/0/1201812548509877/1205892550401136/f

## Checklist

- [x] Pasted Asana link.
- [x] Tagged labels.

## Prerequisite/Related Pull Requests

<!-- Please paste the related PR links. -->
