### PR TITLE
Fix: wagami connector support chain

### DIFF
--- a/.changeset/four-seals-dance.md
+++ b/.changeset/four-seals-dance.md
@@ -1,0 +1,5 @@
+---
+'@blocto/wagmi-connector': minor
+---
+
+Get blocto support list through api

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -2,13 +2,13 @@
   "mode": "exit",
   "tag": "beta",
   "initialVersions": {
-    "@blocto/aptos-wallet-adapter-plugin": "0.2.7-beta.0",
-    "@blocto/connectkit-connector": "0.2.2-beta.0",
-    "@blocto/rainbowkit-connector": "0.2.8-beta.0",
-    "@blocto/wagmi-connector": "1.2.4-beta.0",
-    "@blocto/web3-react-connector": "1.0.5-beta.1",
-    "@blocto/web3modal-connector": "0.1.3-beta.0",
-    "@blocto/sdk": "0.8.1-beta.1",
+    "@blocto/aptos-wallet-adapter-plugin": "0.2.7-beta.1",
+    "@blocto/connectkit-connector": "0.2.2-beta.1",
+    "@blocto/rainbowkit-connector": "0.2.8-beta.1",
+    "@blocto/wagmi-connector": "1.2.4-beta.1",
+    "@blocto/web3-react-connector": "1.0.5-beta.2",
+    "@blocto/web3modal-connector": "0.1.3-beta.1",
+    "@blocto/sdk": "0.9.0-beta.2",
     "@blocto/dappauth": "2.2.0",
     "eslint-config-custom": "0.0.0",
     "tsconfig": "0.0.0"
@@ -18,8 +18,10 @@
     "angry-turkeys-complain",
     "eight-pugs-shop",
     "fluffy-pandas-rule",
+    "four-seals-dance",
     "polite-wasps-clean",
     "pretty-lobsters-wonder",
-    "thin-dingos-share"
+    "thin-dingos-share",
+    "warm-rats-peel"
   ]
 }

--- a/adapters/connectkit-connector/CHANGELOG.md
+++ b/adapters/connectkit-connector/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @blocto/connectkit-connector
 
+## 0.2.2-beta.2
+
+### Patch Changes
+
+- Updated dependencies [fce0e50]
+  - @blocto/wagmi-connector@1.3.0-beta.2
+
 ## 0.2.2-beta.1
 
 ### Patch Changes

--- a/adapters/connectkit-connector/package.json
+++ b/adapters/connectkit-connector/package.json
@@ -2,7 +2,7 @@
   "name": "@blocto/connectkit-connector",
   "description": "blocto wallet connector to use with connectkit",
   "author": "Blocto Wallet",
-  "version": "0.2.2-beta.1",
+  "version": "0.2.2-beta.2",
   "type": "module",
   "main": "./dist/index.umd.cjs",
   "module": "./dist/index.js",
@@ -30,7 +30,7 @@
     "/dist"
   ],
   "dependencies": {
-    "@blocto/wagmi-connector": "^1.2.4-beta.1"
+    "@blocto/wagmi-connector": "^1.3.0-beta.2"
   },
   "peerDependencies": {
     "connectkit": "^1.5.3",

--- a/adapters/rainbowkit-connector/CHANGELOG.md
+++ b/adapters/rainbowkit-connector/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @blocto/rainbowkit-connector
 
+## 0.2.8-beta.2
+
+### Patch Changes
+
+- Updated dependencies [fce0e50]
+  - @blocto/wagmi-connector@1.3.0-beta.2
+
 ## 0.2.8-beta.1
 
 ### Patch Changes

--- a/adapters/rainbowkit-connector/package.json
+++ b/adapters/rainbowkit-connector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blocto/rainbowkit-connector",
-  "version": "0.2.8-beta.1",
+  "version": "0.2.8-beta.2",
   "description": "blocto wallet connector to use rainbowkit",
   "author": "Blocto Wallet",
   "main": "./dist/index.js",
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@rainbow-me/rainbowkit": "^1.0.8",
-    "@blocto/wagmi-connector": "^1.2.4-beta.1"
+    "@blocto/wagmi-connector": "^1.3.0-beta.2"
   },
   "devDependencies": {
     "@types/jest": "^29.5.2",

--- a/adapters/wagmi-connector/CHANGELOG.md
+++ b/adapters/wagmi-connector/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @blocto/wagmi-connector
 
+## 1.3.0-beta.2
+
+### Minor Changes
+
+- fce0e50: Get blocto support list through api
+
+### Patch Changes
+
+- Updated dependencies [d34fca2]
+  - @blocto/sdk@0.9.0-beta.3
+
 ## 1.2.4-beta.1
 
 ### Patch Changes

--- a/adapters/wagmi-connector/package.json
+++ b/adapters/wagmi-connector/package.json
@@ -2,7 +2,7 @@
   "name": "@blocto/wagmi-connector",
   "description": "Blocto wallet connector extend from wagmi Connector",
   "author": "Calvin Chang",
-  "version": "1.2.4-beta.1",
+  "version": "1.3.0-beta.2",
   "type": "module",
   "main": "./dist/index.umd.cjs",
   "module": "./dist/index.js",
@@ -28,7 +28,7 @@
     "/dist"
   ],
   "dependencies": {
-    "@blocto/sdk": "^0.9.0-beta.2"
+    "@blocto/sdk": "^0.9.0-beta.3"
   },
   "peerDependencies": {
     "@wagmi/core": ">=1",

--- a/adapters/wagmi-connector/src/connector.ts
+++ b/adapters/wagmi-connector/src/connector.ts
@@ -133,23 +133,23 @@ class BloctoConnector extends Connector<BloctoProvider, BloctoOptions> {
   }
 
   async switchChain(chainId: number): Promise<Chain> {
-    const provider = await this.getProvider();
-    const id = numberToHex(chainId);
-    const chain = this.chains.find((x) => x.id === chainId);
-    const { networks } = await fetch(
-      'https://api.blocto.app/networks/evm'
-    ).then((response) => response.json());
-    const evmSupportMap = networks.reduce(
-      (a: any, v: any) => ({ ...a, [v.chain_id]: v }),
-      {}
-    );
-    const isBloctoSupportChain = evmSupportMap[`${chainId}`];
-
-    if (!chain || !isBloctoSupportChain) {
-      throw new SwitchChainError(new Error(`Blocto unsupported chain: ${id}`));
-    }
-
     try {
+      const provider = await this.getProvider();
+      const id = numberToHex(chainId);
+      const chain = this.chains.find((x) => x.id === chainId);
+      const networks = await provider.supportChainList();
+      const evmSupportMap = networks.reduce(
+        (a: any, v: any) => ({ ...a, [v.chain_id]: v }),
+        {}
+      );
+      const isBloctoSupportChain = evmSupportMap[`${chainId}`];
+
+      if (!chain || !isBloctoSupportChain) {
+        throw new SwitchChainError(
+          new Error(`Blocto unsupported chain: ${id}`)
+        );
+      }
+
       await provider.request({
         method: 'wallet_addEthereumChain',
         params: [{ chainId: id, rpcUrls: chain?.rpcUrls.default.http }],

--- a/adapters/web3modal-connector/CHANGELOG.md
+++ b/adapters/web3modal-connector/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @blocto/web3modal-connector
 
+## 0.1.3-beta.2
+
+### Patch Changes
+
+- Updated dependencies [fce0e50]
+  - @blocto/wagmi-connector@1.3.0-beta.2
+
 ## 0.1.3-beta.1
 
 ### Patch Changes

--- a/adapters/web3modal-connector/package.json
+++ b/adapters/web3modal-connector/package.json
@@ -2,7 +2,7 @@
   "name": "@blocto/web3modal-connector",
   "description": "Blocto connector extend from wagmi Connector to use with web3modal",
   "author": "Blocto Wallet",
-  "version": "0.1.3-beta.1",
+  "version": "0.1.3-beta.2",
   "type": "module",
   "main": "./dist/index.umd.cjs",
   "module": "./dist/index.js",
@@ -41,6 +41,6 @@
     "/dist"
   ],
   "dependencies": {
-    "@blocto/wagmi-connector": "^1.2.4-beta.1"
+    "@blocto/wagmi-connector": "^1.3.0-beta.2"
   }
 }

--- a/packages/blocto-sdk/CHANGELOG.md
+++ b/packages/blocto-sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @blocto/sdk
 
+## 0.9.0-beta.3
+
+### Minor Changes
+
+- d34fca2: Add RPC endpoints for the L2 chains (Sepolia, Arbitrum Sepolia, Optimism Sepolia, Base, Base Goerli, Base Sepolia, Zora, Zora Goerli, Zora Sepolia, Scroll, Scroll Goerli, Scroll Sepolia, Linea, Linea Goerli and zKatana Sepolia)
+
 ## 0.9.0-beta.2
 
 ### Minor Changes

--- a/packages/blocto-sdk/package.json
+++ b/packages/blocto-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blocto/sdk",
-  "version": "0.9.0-beta.2",
+  "version": "0.9.0-beta.3",
   "repository": "git@github.com:portto/blocto-sdk.git",
   "author": "Chiaki.C",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Due to Blocto SDK structure change, connectors needs to get support chain list from api.

## Related Links

<!-- Asana Ticket / Mockup Design Prototype -->

**Asana**: https://app.asana.com/0/1201812548509877/1206155886507408/f

## Checklist

- [ ] Pasted Asana link.
- [ ] Tagged labels.

## Prerequisite/Related Pull Requests

<!-- Please paste the related PR links. -->
