### PR TITLE
fix: duplicate pop-up authn Iframe

### DIFF
--- a/.changeset/unlucky-masks-heal.md
+++ b/.changeset/unlucky-masks-heal.md
@@ -1,0 +1,6 @@
+---
+'@blocto/web3-react-connector': patch
+'@blocto/sdk': patch
+---
+
+fix web3-react-connector duplicate authn popup

--- a/adapters/web3-react-connector/src/index.ts
+++ b/adapters/web3-react-connector/src/index.ts
@@ -43,7 +43,7 @@ export class BloctoConnector extends Connector {
           rpc: this.options.rpc,
         },
       });
-      this.provider = bloctoSDK.ethereum as unknown as Provider;
+      this.provider = (bloctoSDK.ethereum as unknown) as Provider;
     }
 
     if (!this.provider) throw new Error('Blocto Provider not found');
@@ -54,9 +54,9 @@ export class BloctoConnector extends Connector {
   private async getChainId(): Promise<string> {
     return (await this.provider?.request({ method: 'eth_chainId' })) as string;
   }
-  
+
   public async activate(
-    desiredChainIdOrChainParameters?:AddEthereumChainParameter
+    desiredChainIdOrChainParameters?: AddEthereumChainParameter
   ): Promise<void> {
     const desiredChainId = desiredChainIdOrChainParameters?.chainId;
     const provider = this.getProvider();
@@ -66,7 +66,9 @@ export class BloctoConnector extends Connector {
       !desiredChainId ||
       parseChainId(desiredChainId) === parseChainId(chainId)
     ) {
-      const accounts = await provider.request({ method: 'eth_requestAccounts' }) as string[];
+      const accounts = (await provider.request({
+        method: 'eth_requestAccounts',
+      })) as string[];
 
       return this.actions.update({
         chainId: parseChainId(chainId),
@@ -74,21 +76,21 @@ export class BloctoConnector extends Connector {
       });
     }
 
-      // switch chain
-      await provider.request({
-          method: 'wallet_addEthereumChain',
-          params: [desiredChainIdOrChainParameters],
-        })
+    // switch chain
+    await provider.request({
+      method: 'wallet_addEthereumChain',
+      params: [desiredChainIdOrChainParameters],
+    });
 
-      await provider.request({
-        method: 'wallet_switchEthereumChain',
-        params: [{ chainId: desiredChainId }],
-      });
+    await provider.request({
+      method: 'wallet_switchEthereumChain',
+      params: [{ chainId: desiredChainId }],
+    });
   }
 
   public deactivate(): void {
     const provider = this.getProvider();
-    
+
     provider.request({ method: 'wallet_disconnect' });
     this.actions.resetState();
   }

--- a/packages/blocto-sdk/src/providers/ethereum.ts
+++ b/packages/blocto-sdk/src/providers/ethereum.ts
@@ -163,7 +163,8 @@ export default class EthereumProvider
           name,
           display_name,
           network_type,
-          wallet_web_url: this._blocto.walletServer,
+          wallet_web_url: this.injectedWalletServer ||
+          ETH_ENV_WALLET_SERVER_MAPPING[blocto_service_environment],
           rpc_url: this.rpc,
         },
       },
@@ -443,6 +444,7 @@ export default class EthereumProvider
       case 'wallet_addEthereumChain': {
         return this.loadSwitchableNetwork(payload?.params || []);
       }
+      case 'eth_blockNumber':
       case 'eth_call': {
         const response = await this.handleReadRequests(payload);
         if (!response || (response && !response.result && response.error)) {
@@ -462,8 +464,9 @@ export default class EthereumProvider
       case 'wallet_disconnect': {
         return this.handleDisconnect();
       }
-      case 'eth_accounts':
+      case 'eth_accounts': {
         return getEvmAddress(sessionKeyEnv, blockchainName) || [];
+      }
     }
 
     // Method that requires user to be connected

--- a/packages/blocto-sdk/src/providers/ethereum.ts
+++ b/packages/blocto-sdk/src/providers/ethereum.ts
@@ -445,6 +445,7 @@ export default class EthereumProvider
         return this.loadSwitchableNetwork(payload?.params || []);
       }
       case 'eth_blockNumber':
+      case 'web3_clientVersion':
       case 'eth_call': {
         const response = await this.handleReadRequests(payload);
         if (!response || (response && !response.result && response.error)) {

--- a/packages/blocto-sdk/src/providers/ethereum.ts
+++ b/packages/blocto-sdk/src/providers/ethereum.ts
@@ -149,12 +149,13 @@ export default class EthereumProvider
         `Get support chain failed: ${this.networkVersion} might not be supported yet.`
       );
     }
+    const walletServer =
+      this.injectedWalletServer ||
+      ETH_ENV_WALLET_SERVER_MAPPING[blocto_service_environment];
     this._blocto = {
       ...this._blocto,
       sessionKeyEnv: ETH_SESSION_KEY_MAPPING[blocto_service_environment],
-      walletServer:
-        this.injectedWalletServer ||
-        ETH_ENV_WALLET_SERVER_MAPPING[blocto_service_environment],
+      walletServer,
       blockchainName: name,
       networkType: network_type,
       switchableNetwork: {
@@ -163,8 +164,7 @@ export default class EthereumProvider
           name,
           display_name,
           network_type,
-          wallet_web_url: this.injectedWalletServer ||
-          ETH_ENV_WALLET_SERVER_MAPPING[blocto_service_environment],
+          wallet_web_url: walletServer,
           rpc_url: this.rpc,
         },
       },


### PR DESCRIPTION
## Summary

<!--- Provide enough context about what you’re trying to achieve. You can break it down in a few bullet-points.-->

- fix `this._blocto` updating operation in ethereum provider's `#getBloctoProperties()`
- remove `isomorphicInitialize()` to avoid repeat add eventlistener's callback fn
- handle `action.update({ ... })` in event callback fn to avoid repeat open iframe
- add `method: 'eth_blockNumber` & `method:  'web3_clientVersion'` to non-connected switch blocks to prevent the authn Iframe from opening when uniswap calls `eth_blockNumber` & `web3_clientVersion`.

## Related Links

<!-- Asana Ticket / Mockup Design Prototype -->

**Asana**:https://app.asana.com/0/1201812548509877/1205974827065486/f

## Checklist

- [x] Pasted Asana link.
- [x] Tagged labels.

## Prerequisite/Related Pull Requests

<!-- Please paste the related PR links. -->
![iShot_2023-12-29_14 51 22](https://github.com/blocto/blocto-sdk/assets/46014714/c02939aa-fdbd-4b5d-87fc-a2e6c18e61a6)
