### PR TITLE
fix(web3-react): replace eth_accounts with eth_requestAccounts

### DIFF
--- a/.changeset/pink-pumpkins-give.md
+++ b/.changeset/pink-pumpkins-give.md
@@ -1,0 +1,5 @@
+---
+'@blocto/web3-react-connector': patch
+---
+
+fix(web3-react): use eth_requestAccounts replace eth_accounts

--- a/adapters/web3-react-connector/src/index.ts
+++ b/adapters/web3-react-connector/src/index.ts
@@ -46,7 +46,7 @@ export class BloctoConnector extends Connector {
       'connect',
       async ({ chainId }: ProviderConnectInfo): Promise<void> => {
         const accounts = await this.provider.request({
-          method: 'eth_accounts',
+          method: 'eth_requestAccounts',
         });
         this.actions.update({ chainId: parseChainId(chainId), accounts });
       }
@@ -56,7 +56,9 @@ export class BloctoConnector extends Connector {
       this.onError?.(error);
     });
     this.provider.on('chainChanged', async (chainId: string): Promise<void> => {
-      const accounts = await this.provider.request({ method: 'eth_accounts' });
+      const accounts = await this.provider.request({
+        method: 'eth_requestAccounts',
+      });
       this.actions.update({ chainId: parseChainId(chainId), accounts });
     });
     this.provider.on('accountsChanged', (accounts: string[]): void => {

--- a/adapters/web3-react-connector/src/index.ts
+++ b/adapters/web3-react-connector/src/index.ts
@@ -61,10 +61,6 @@ export class BloctoConnector extends Connector {
       });
       this.actions.update({ chainId: parseChainId(chainId), accounts });
     });
-    this.provider.on('accountsChanged', (accounts: string[]): void => {
-      if (accounts.length === 0) this.actions.resetState();
-      else this.actions.update({ accounts });
-    });
   }
 
   public async activate(


### PR DESCRIPTION
## Summary

<!--- Provide enough context about what you’re trying to achieve. You can break it down in a few bullet-points.-->
- replace `eth_accounts` with `eth_requestAccounts` to avoid returning empty accounts in switch chain before connecting
- remove the unnecessary `onAccountChanged` handling because blocto's account switch requires re-connecting, and this will trigger the `connect` event at that time.

## Related Links

<!-- Asana Ticket / Mockup Design Prototype -->

**Asana**:

## Checklist

- [ ] Pasted Asana link.
- [x] Tagged labels.

## Prerequisite/Related Pull Requests

<!-- Please paste the related PR links. -->
