### PR TITLE
fix: clear wagmi switch chain error

### DIFF
--- a/.changeset/wicked-shirts-flash.md
+++ b/.changeset/wicked-shirts-flash.md
@@ -1,0 +1,5 @@
+---
+'@blocto/wagmi-connector': patch
+---
+
+Show not in config error message when attempt to switch dapp unsupport chain

--- a/adapters/wagmi-connector/src/connector.ts
+++ b/adapters/wagmi-connector/src/connector.ts
@@ -124,7 +124,11 @@ export function blocto({ appId }: BloctoParameters = {}) {
         );
         const isBloctoSupportChain = evmSupportMap[`${chainId}`];
 
-        if (!chain || !isBloctoSupportChain) {
+        if (!chain) {
+          throw new SwitchChainError(new Error(`Chain not in config: ${id}`));
+        }
+
+        if (!isBloctoSupportChain) {
           throw new SwitchChainError(
             new Error(`Blocto unsupported chain: ${id}`)
           );


### PR DESCRIPTION
## Summary

If dev didn't add target chain in config, show not in config error instead of blocto not support.

## Related Links

<!-- Asana Ticket / Mockup Design Prototype -->

**Asana**:

## Checklist

- [ ] Pasted Asana link.
- [ ] Tagged labels.

## Prerequisite/Related Pull Requests

<!-- Please paste the related PR links. -->
