### PR TITLE
Fix/getting wrong chain id in in app browser

### DIFF
--- a/.changeset/afraid-hairs-exercise.md
+++ b/.changeset/afraid-hairs-exercise.md
@@ -1,0 +1,5 @@
+---
+'@blocto/wagmi-connector': patch
+---
+
+fix(wagmi): obtain chainId through request

--- a/adapters/wagmi-connector/src/connector.ts
+++ b/adapters/wagmi-connector/src/connector.ts
@@ -74,9 +74,7 @@ export function blocto({ appId }: BloctoParameters = {}) {
     },
     async getChainId() {
       const provider = await this.getProvider();
-      const chainId =
-        provider.chainId ??
-        (await provider?.request({ method: 'eth_chainId' }));
+      const chainId = await provider?.request({ method: 'eth_chainId' });
       return normalizeChainId(chainId);
     },
     async getProvider({ chainId } = {}) {


### PR DESCRIPTION
## Summary

<!--- Provide enough context about what you’re trying to achieve. You can break it down in a few bullet-points.-->
fetching `chainId` through `request({ method: 'eth_chainId' })` instead of `provider.chainId`,
to avoid inconsistencies between existedSDK and BloctoSDK‘s instance on the chainId.

## Related Links

<!-- Asana Ticket / Mockup Design Prototype -->

**Asana**: https://app.asana.com/0/1206187776629256/1206425584375066/f

## Checklist

- [x] Pasted Asana link.
- [x] Tagged labels.

## Prerequisite/Related Pull Requests

<!-- Please paste the related PR links. -->
